### PR TITLE
Deploy only on push to main branch or when closing a PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,11 @@
 name: deploy-to-server
-on: [push]
+on:
+  pull_request:
+    types:
+      - closed
+  push:
+    branches:
+      - main
       
 jobs:
   build:


### PR DESCRIPTION
It seems the whole workload is deployed every time someone pushes to the repo regardless of the branch being pushed to. This restricts the deployment automation to pushes to the main branch and closed PR.